### PR TITLE
Don't drop the last packet of a stream

### DIFF
--- a/Concentus.Oggfile/OpusOggReadStream.cs
+++ b/Concentus.Oggfile/OpusOggReadStream.cs
@@ -265,7 +265,7 @@ namespace Concentus.Oggfile
             }
 
             DataPacket packet = _packetProvider.GetNextPacket();
-            if (packet == null || packet.IsEndOfStream)
+            if (packet == null)
             {
                 _endOfStream = true;
                 _nextDataPacket = null;


### PR DESCRIPTION
`OpusOggReadStream.QueueNextPacket()` drops the packet if it's the last packet of the stream.

That packet still contains audio samples, and dropping it may not be acceptable
behavior depending on the application's needs.

In my case (a video game which I'm porting from another game engine to Unity), we have music files with A-B loop points. Some files have the B point as the very last sample in the file... which is in the packet `OpusOggReadStream` drops.

Since I don't see any reason to drop the last packet, this pull request simply stops dropping it, allowing it to be returned to the application.