### PR TITLE
Add leaveOpen flag to control stream disposal

### DIFF
--- a/Concentus.Oggfile/OpusRawWriteStream.cs
+++ b/Concentus.Oggfile/OpusRawWriteStream.cs
@@ -15,6 +15,7 @@ namespace Concentus.Oggfile
         private Stream _outputStream;
         private Crc _crc;
         private int _inputChannels;
+        private readonly bool _leaveOpen;
         private int _inputSampleRate;
 
         // Ogg page parameters
@@ -32,11 +33,12 @@ namespace Concentus.Oggfile
         private const int SEGMENT_COUNT_POS = 26;
         private bool _finalized = false;
 
-        public OpusRawWriteStream(Stream outputStream, OpusTags fileTags, int inputSampleRate, int inputNumChannels)
+        public OpusRawWriteStream(Stream outputStream, OpusTags fileTags, int inputSampleRate, int inputNumChannels, bool leaveOpen = false)
         {
             _inputSampleRate = inputSampleRate;
             _logicalStreamId = new Random().Next();
             _inputChannels = inputNumChannels;
+            _leaveOpen = leaveOpen;
             _outputStream = outputStream;
             _granulePosition = 0;
             _crc = new Crc();
@@ -99,7 +101,8 @@ namespace Concentus.Oggfile
 
             // Now close our output
             _outputStream.Flush();
-            _outputStream.Dispose();
+            if (!_leaveOpen)
+                _outputStream.Dispose();
             _finalized = true;
         }
 


### PR DESCRIPTION
- See [StreamWriter](https://learn.microsoft.com/en-us/dotnet/api/system.io.streamwriter.-ctor?view=net-8.0#system-io-streamwriter-ctor(system-io-stream-system-text-encoding-system-int32-system-boolean))
- See [DeflateStream](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.deflatestream.-ctor?view=net-8.0#system-io-compression-deflatestream-ctor(system-io-stream-system-io-compression-compressionmode-system-boolean))
- See https://github.com/lostromb/concentus.oggfile/issues/26 (mentions above)

There were many opportunities to update the rest of the codebase, but I stepped back from doing that for now.