### PR TITLE
Resolved issue with Container Reader not being closed/disposed.

### DIFF
--- a/Concentus.Oggfile/Concentus.Oggfile.csproj
+++ b/Concentus.Oggfile/Concentus.Oggfile.csproj
@@ -1,36 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net452;netstandard1.1;netstandard2.0;net8.0</TargetFrameworks>
-    <Id>Concentus.OggFile</Id>
-    <Version>1.0.5.0</Version>
-    <Title>Concentus.OggFile</Title>
-    <Authors>Logan Stromberg</Authors>
-    <Owners>Logan Stromberg</Owners>
-    <Summary>OggOpus file handlers utilizing the Concentus codec</Summary>
-    <Description>This package implements file streams which can be used to extract or encode Opus packets in an Ogg-formatted audio file (usually .opus), giving developers a very simple API to perform the task of reading or writing audio files that can be played universally. The Concentus library is used to encode/decode the opus packets automatically. The codec can optionally be accelerated by also referencing the Concentus.Native package.</Description>
-    <ReleaseNotes>Proper netstandard support</ReleaseNotes>
-    <ProjectUrl>https://github.com/lostromb/concentus.oggfile</ProjectUrl>
-    <LicenseUrl>https://opensource.org/licenses/MS-PL</LicenseUrl>
-    <Copyright>Copyright © Logan Stromberg, Andrew Ward</Copyright>
-    <Tags>Concentus Opus Ogg Audio Encoding Decoding Codec Container Media</Tags>
-    <IconUrl>http://durandal.dnsalias.net/imgur/concentus.png</IconUrl>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageProjectUrl>https://github.com/lostromb/concentus.oggfile</PackageProjectUrl>
-    <PackageIconUrl>http://durandal.dnsalias.net/imgur/concentus.png</PackageIconUrl>
-    <PackageReleaseNotes>1.0.5 Update to latest Concentus dependency to allow native codec implementations if desired (see the release notes for Concentus.Native)</PackageReleaseNotes>
-    <RepositoryUrl>https://github.com/lostromb/concentus.oggfile</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageLicenseExpression>MS-PL</PackageLicenseExpression>
-    <PackageIcon>icon.png</PackageIcon>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Include="..\icon.png">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net452;netstandard1.1;netstandard2.0;net8.0</TargetFrameworks>
+		<Id>Concentus.OggFile</Id>
+		<Version>1.0.6.0</Version>
+		<Title>Concentus.OggFile</Title>
+		<Authors>Logan Stromberg</Authors>
+		<Owners>Logan Stromberg</Owners>
+		<Summary>OggOpus file handlers utilizing the Concentus codec</Summary>
+		<Description>This package implements file streams which can be used to extract or encode Opus packets in an Ogg-formatted audio file (usually .opus), giving developers a very simple API to perform the task of reading or writing audio files that can be played universally. The Concentus library is used to encode/decode the opus packets automatically. The codec can optionally be accelerated by also referencing the Concentus.Native package.</Description>
+		<ReleaseNotes>Proper netstandard support</ReleaseNotes>
+		<ProjectUrl>https://github.com/lostromb/concentus.oggfile</ProjectUrl>
+		<LicenseUrl>https://opensource.org/licenses/MS-PL</LicenseUrl>
+		<Copyright>Copyright © Logan Stromberg, Andrew Ward</Copyright>
+		<Tags>Concentus Opus Ogg Audio Encoding Decoding Codec Container Media</Tags>
+		<IconUrl>http://durandal.dnsalias.net/imgur/concentus.png</IconUrl>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<PackageProjectUrl>https://github.com/lostromb/concentus.oggfile</PackageProjectUrl>
+		<PackageIconUrl>http://durandal.dnsalias.net/imgur/concentus.png</PackageIconUrl>
+		<PackageReleaseNotes>1.0.5 Update to latest Concentus dependency to allow native codec implementations if desired (see the release notes for Concentus.Native)</PackageReleaseNotes>
+		<RepositoryUrl>https://github.com/lostromb/concentus.oggfile</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageLicenseExpression>MS-PL</PackageLicenseExpression>
+		<PackageIcon>icon.png</PackageIcon>
+	</PropertyGroup>
+	<ItemGroup>
+		<None Include="..\icon.png">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Concentus" Version="2.2.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Concentus" Version="2.2.2" />
+	</ItemGroup>
 </Project>

--- a/Concentus.Oggfile/OpusHeader.cs
+++ b/Concentus.Oggfile/OpusHeader.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+#pragma warning disable 0169
+
 namespace Concentus.Oggfile
 {
     internal class OpusHeader
@@ -18,3 +20,5 @@ namespace Concentus.Oggfile
         byte coupled_count;
     }
 }
+
+#pragma warning restore 0169

--- a/Concentus.Oggfile/OpusOggReadStream.cs
+++ b/Concentus.Oggfile/OpusOggReadStream.cs
@@ -19,6 +19,8 @@ namespace Concentus.Oggfile
         private IPacketProvider _packetProvider;
         private bool _endOfStream;
 
+        private OggContainerReader _containerReader;
+
         /// <summary>
         /// Builds an Ogg file reader that decodes Opus packets from the given input stream, using a 
         /// specified output sample rate and channel count. The given decoder will be used as-is
@@ -158,14 +160,18 @@ namespace Concentus.Oggfile
                 if (!oggContainerReader.Init())
                 {
                     LastError = "Could not initialize stream";
+                    oggContainerReader.Dispose();
                     return false;
                 }
 
                 if (oggContainerReader.StreamSerials.Length == 0)
                 {
                     LastError = "Initialization failed: No elementary streams found in input file";
+                    oggContainerReader.Dispose();
                     return false;
                 }
+
+                _containerReader = oggContainerReader;
 
                 int firstStreamSerial = oggContainerReader.StreamSerials[0];
                 _packetProvider = oggContainerReader.GetStream(firstStreamSerial);
@@ -308,6 +314,11 @@ namespace Concentus.Oggfile
             {
                 _nextDataPacket = buf;
             }
+        }
+
+        public void Close()
+        {
+            _containerReader?.Dispose();
         }
     }
 }


### PR DESCRIPTION
Resolved issue with Container Reader not being closed/disposed when finished using the reader.
Suggested increment version to 1.0.6.0
Updated to depend on Concentus 2.2.2