### PR TITLE
Add configurable page size limits for Ogg write streams

### DIFF
--- a/Concentus.Oggfile/OpusOggWriteStream.cs
+++ b/Concentus.Oggfile/OpusOggWriteStream.cs
@@ -1,4 +1,4 @@
-﻿using Concentus.Common;
+using Concentus.Common;
 using Concentus.Structs;
 using System;
 using System.Collections.Generic;
@@ -20,6 +20,7 @@ namespace Concentus.Oggfile
     public class OpusOggWriteStream
     {
         private const int FRAME_SIZE_MS = 20;
+        private const byte EARLY_FINALIZE_SEGMENT_LIMIT = 248;
 
         private IOpusEncoder _encoder;
         private Stream _outputStream;
@@ -43,7 +44,9 @@ namespace Concentus.Oggfile
         private int _pageCounter = 0;
         private int _logicalStreamId = 0;
         private long _granulePosition = 0;
+        private byte _packetsInPage = 0;
         private byte _lacingTableCount = 0;
+        private byte _maxPacketsPerPage = EARLY_FINALIZE_SEGMENT_LIMIT;
         private const int PAGE_FLAGS_POS = 5;
         private const int GRANULE_COUNT_POS = 6;
         private const int CHECKSUM_HEADER_POS = 22;
@@ -97,6 +100,31 @@ namespace Concentus.Oggfile
             BeginNewPage();
             WriteOpusHeadPage();
             WriteOpusTagsPage(fileTags);
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum amount of encoded audio to store in a single Ogg page.
+        /// This stream encodes fixed 20ms Opus frames, so this option allows more
+        /// frequent page breaks to reduce streaming delay at the cost of larger Ogg overhead.
+        /// Pages are still finalized earlier if the Ogg lacing table is nearly full.
+        /// </summary>
+        public TimeSpan MaxAudioLengthPerPage
+        {
+            get
+            {
+                return TimeSpan.FromMilliseconds(FRAME_SIZE_MS * _maxPacketsPerPage);
+            }
+            set
+            {
+                if (value <= TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(MaxAudioLengthPerPage));
+                }
+
+                _maxPacketsPerPage = (byte)Math.Min(
+                    EARLY_FINALIZE_SEGMENT_LIMIT,
+                    Math.Max(1, (int)(value.TotalMilliseconds / FRAME_SIZE_MS)));
+            }
         }
 
         /// <summary>
@@ -171,11 +199,12 @@ namespace Concentus.Oggfile
 
                     _currentHeader[_headerIndex++] = (byte)segmentLength;
                     _lacingTableCount++;
+                    _packetsInPage++;
 
-                    // And finalize the page if we need
-                    // 284 is a magic number meaning "our page is almost full so just finalize it"
+                    // Finalize early either because we hit the configured audio-per-page limit
+                    // or because the Ogg lacing table is almost full.
                     // A more proper implementation would have the packets span to the next page, but meh
-                    if (_lacingTableCount > 248)
+                    if (_packetsInPage >= _maxPacketsPerPage || _lacingTableCount > EARLY_FINALIZE_SEGMENT_LIMIT)
                     {
                         FinalizePage();
                     }
@@ -350,6 +379,7 @@ namespace Concentus.Oggfile
         {
             _headerIndex = 0;
             _payloadIndex = 0;
+            _packetsInPage = 0;
             _lacingTableCount = 0;
 
             // Page begin keyword

--- a/Concentus.Oggfile/OpusRawWriteStream.cs
+++ b/Concentus.Oggfile/OpusRawWriteStream.cs
@@ -1,4 +1,4 @@
-﻿using Concentus.Common;
+using Concentus.Common;
 using Concentus.Structs;
 using System;
 using System.Collections.Generic;
@@ -318,3 +318,4 @@ namespace Concentus.Oggfile
         }
     }
 }
+


### PR DESCRIPTION
## Summary

This PR adds configurable automatic page breaking to the Ogg write streams so callers can reduce streaming latency without relying on reflection or changing the default behavior for file-oriented use.

## Motivation

The current writers keep appending packets to the current Ogg page until the internal "almost full" threshold is reached.

That works well for normal file output, but for streaming scenarios it can add avoidable latency because a larger amount of encoded audio may remain buffered in the current page before it is emitted.

We need a supported way to bound page size while keeping the existing default behavior intact.

## Change

Added:

- `OpusOggWriteStream.MaxAudioLengthPerPage`
- `OpusRawWriteStream.MaxPacketsPerPage`

Behavior:

- `OpusOggWriteStream` now finalizes pages automatically once the configured audio-per-page limit is reached.
- `OpusRawWriteStream` now finalizes pages automatically once the configured packet-per-page limit is reached.
- The existing early-finalization safeguard for near-full Ogg pages is still preserved.
- Default behavior is unchanged unless one of the new properties is explicitly set.

## Notes

`OpusOggWriteStream` exposes a `TimeSpan` because that stream produces fixed 20 ms Opus frames internally.

`OpusRawWriteStream` exposes a packet count because it accepts already-encoded Opus packets, whose durations may vary.
